### PR TITLE
[Riemann] Updating download URL

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,7 @@ class riemann::install {
   }
 
   wget::fetch { 'download_riemann':
-    source      => "http://aphyr.com/riemann/riemann-${riemann::version}.tar.bz2",
+    source      => "https://github.com/riemann/riemann/releases/download/${riemann::version}/riemann-${riemann::version}.tar.bz2",
     destination => "/usr/local/src/riemann-${riemann::version}.tar.bz2",
     before      => Exec['untar_riemann'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class riemann::params {
   $dash_user = 'riemann-dash'
   $net_user = 'riemann-net'
   $health_user = 'riemann-health'
-  $port = 5555
+  $port = '5555'
   $host = 'localhost'
   $user = 'riemann'
   $rvm_ruby_string = undef


### PR DESCRIPTION
The old URL is dead. The new releases are hosted on Github.

PD-2956

(The quotes around the port number are not related, but provisioning keeps failing with no quotes.)