### PR TITLE
[Riemann] Package and Xenial Support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,49 +4,53 @@ class riemann::config {
   $config_file = $riemann::config_file
   $user = $riemann::user
 
-  case $::osfamily {
-    'Debian': {
-      file { '/etc/init.d/riemann':
-        ensure => link,
-        target => '/lib/init/upstart-job',
-      }
+  if $riemann::use_package == false {
 
-      file { '/etc/init/riemann.conf':
+    case $::osfamily {
+      'Debian': {
+        file { '/etc/init.d/riemann':
+          ensure => link,
+          target => '/lib/init/upstart-job',
+        }
+  
+        file { '/etc/init/riemann.conf':
+          ensure  => present,
+          content => template('riemann/etc/init/riemann.conf.erb')
+        }
+      }
+      'RedHat', 'Amazon': {
+        file { '/etc/init.d/riemann':
+          ensure  => present,
+          mode    => '0755',
+          content => template('riemann/etc/init/riemann.conf.redhat.erb')
+        }
+      }
+      default: {}
+    }
+ 
+  }
+  
+    file { '/etc/riemann.sample.config':
+      ensure => present,
+      source => 'puppet:///modules/riemann/etc/riemann.config',
+      owner  => $user,
+    }
+
+    if versioncmp($::puppetversion, '4.0.0') >= 0 {
+      file { '/etc/puppetlabs/riemann.yaml':
         ensure  => present,
-        content => template('riemann/etc/init/riemann.conf.erb')
+        content => template('riemann/etc/puppet/riemann.yaml.erb')
       }
     }
-    'RedHat', 'Amazon': {
-      file { '/etc/init.d/riemann':
+    else {
+      file { '/etc/puppet/riemann.yaml':
         ensure  => present,
-        mode    => '0755',
-        content => template('riemann/etc/init/riemann.conf.redhat.erb')
+        content => template('riemann/etc/puppet/riemann.yaml.erb')
       }
     }
-    default: {}
-  }
-
-  file { '/etc/riemann.sample.config':
-    ensure => present,
-    source => 'puppet:///modules/riemann/etc/riemann.config',
-    owner  => $user,
-  }
-
-  if versioncmp($::puppetversion, '4.0.0') >= 0  {
-    file { '/etc/puppetlabs/puppet/riemann.yaml':
-      ensure  => present,
-      content => template('riemann/etc/puppet/riemann.yaml.erb')
-    } 
-  }
-  else {
-    file { '/etc/puppet/riemann.yaml':
-      ensure  => present,
-      content => template('riemann/etc/puppet/riemann.yaml.erb')
+     
+    file { '/var/log/riemann.log':
+      owner => $user,
     }
-  }
-
-  file { '/var/log/riemann.log':
-    owner => $user,
-  }
 
 }

--- a/manifests/dash.pp
+++ b/manifests/dash.pp
@@ -23,6 +23,7 @@ class riemann::dash(
   $port = $riemann::params::dash_port,
   $user = $riemann::params::dash_user,
   $rvm_ruby_string = $riemann::params::rvm_ruby_string,
+  $system_user = $riemann::params::system_user,
 ) inherits riemann::params {
   validate_string($host)
   validate_string($user)

--- a/manifests/dash/install.pp
+++ b/manifests/dash/install.pp
@@ -6,7 +6,7 @@ class riemann::dash::install {
 
   user { 'riemann-dash':
     ensure => present,
-    system => true,
+    system => $riemann::dash::system_user,
   }
 
   package { 'riemann-dash':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,13 +26,17 @@ class riemann(
   $host = $riemann::params::host,
   $port = $riemann::params::port,
   $user = $riemann::params::user,
+  $system_user = $riemann::params::system_user,
+  $use_package = $riemann::params::use_package,
 ) inherits riemann::params {
 
   validate_absolute_path($config_file)
   validate_string($version, $host, $port)
+  validate_bool($use_package)
 
   class { 'riemann::install': } ->
   class { 'riemann::config': } ~>
   class { 'riemann::service': } ->
   Class['riemann']
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,51 +1,70 @@
 class riemann::install {
   include wget
   include java
+ 
 
-  case $::osfamily {
-    'Debian': {
-      exec { 'riemann-apt-get-update':
-        command => '/usr/bin/apt-get update',
-        before  => Class['java'],
+  if $riemann::use_package == false { 
+    case $::osfamily {
+      'RedHat', 'Amazon': {
+        ensure_resource('package', 'daemonize', {'ensure' => 'present' })
       }
+      default: {}
     }
-    'RedHat', 'Amazon': {
-      ensure_resource('package', 'daemonize', {'ensure' => 'present' })
+  
+    wget::fetch { 'download_riemann':
+      source      => "https://github.com/riemann/riemann/releases/download/${riemann::version}/riemann-${riemann::version}.tar.bz2",
+      destination => "/usr/local/src/riemann-${riemann::version}.tar.bz2",
+      before      => Exec['untar_riemann'],
     }
-    default: {}
-  }
+  
+    file { '/opt/riemann':
+      ensure  => link,
+      target  => "/opt/riemann-${riemann::version}",
+      owner   => $riemann::user,
+      require => User[$riemann::user],
+    }
+  
+    user { $riemann::user:
+      ensure => present,
+      system => $riemann::system_user,
+    }
+  
+    file { "/opt/riemann-${riemann::version}":
+      ensure  => directory,
+      owner   => $riemann::user,
+      require => User[$riemann::user],
+    }
+  
+    exec { 'untar_riemann':
+      command => "/bin/tar --bzip2 -xvf /usr/local/src/riemann-${riemann::version}.tar.bz2",
+      cwd     => '/opt',
+      creates => "/opt/riemann-${riemann::version}/bin/riemann",
+      before  => File['/opt/riemann'],
+      user    => $riemann::user,
+      require => File["/opt/riemann-${riemann::version}"],
+    }
 
-  wget::fetch { 'download_riemann':
-    source      => "https://github.com/riemann/riemann/releases/download/${riemann::version}/riemann-${riemann::version}.tar.bz2",
-    destination => "/usr/local/src/riemann-${riemann::version}.tar.bz2",
-    before      => Exec['untar_riemann'],
-  }
+  } else {
+    case $::osfamily {
+      'RedHat', 'Amazon': {
+        $_pkg_name = "riemann-${riemann::version}-1.noarch.rpm" 
+        $_pkg_type = "rpm" 
+      }
+      'Debian': {
+        $_pkg_name =  "riemann_${riemann::version}_all.deb"  
+        $_pkg_type = "dpkg" 
+      }
+      default: {}
+    }
 
-  file { '/opt/riemann':
-    ensure  => link,
-    target  => "/opt/riemann-${riemann::version}",
-    owner   => $riemann::user,
-    require => User[$riemann::user],
-  }
-
-  user { $riemann::user:
-    ensure => present,
-    system => true,
-  }
-
-  file { "/opt/riemann-${riemann::version}":
-    ensure  => directory,
-    owner   => $riemann::user,
-    require => User[$riemann::user],
-  }
-
-  exec { 'untar_riemann':
-    command => "/bin/tar --bzip2 -xvf /usr/local/src/riemann-${riemann::version}.tar.bz2",
-    cwd     => '/opt',
-    creates => "/opt/riemann-${riemann::version}/bin/riemann",
-    before  => File['/opt/riemann'],
-    user    => $riemann::user,
-    require => File["/opt/riemann-${riemann::version}"],
+    wget::fetch { 'download_riemann_package':
+      source      => "https://github.com/riemann/riemann/releases/download/${riemann::version}/${_pkg_name}",
+      destination => "/usr/local/src/${_pkg_name}",
+    }
+    package { 'riemann_pkg':
+      source => "/usr/local/src/${_pkg_name}",
+      provider => $_pkg_type,
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,12 +10,27 @@ class riemann::params {
   $host = 'localhost'
   $user = 'riemann'
   $rvm_ruby_string = undef
+  $system_user = false
+  $use_package = false 
 
   case $::osfamily {
     'Debian': {
-      $service_provider = upstart
+      if versioncmp($::operatingsystemrelease, '8.0') >= 0 { 
+        $service_provider = 'systemd'
+      }
+      else {
+        $service_provider = 'upstart'
+      }
       $libxml_package = 'libxml2-dev'
       $libxslt_package = 'libxslt1-dev'
+    }
+    'Ubuntu': {
+      if versioncmp($::operatingsystemrelease, '15.04') >= 0 {
+        $service_provider = 'systemd'
+      }
+      else {
+        $service_provider = 'upstart'
+      }
     }
     'RedHat', 'Amazon': {
       include epel

--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -30,6 +30,7 @@ class riemann::tools(
   $net_enabled = true,
   $net_user = $riemann::params::net_user,
   $rvm_ruby_string = $riemann::params::rvm_ruby_string,
+  $system_user = $riemann::params::system_user,
 ) inherits riemann::params {
   validate_bool($health_enabled, $net_enabled)
   class { 'riemann::tools::install': } ->

--- a/manifests/tools/install.pp
+++ b/manifests/tools/install.pp
@@ -7,14 +7,14 @@ class riemann::tools::install {
   if $riemann::tools::health_enabled == true {
     user { $riemann::tools::health_user:
       ensure => present,
-      system => true,
+      system => $riemann::tools::system_user,
     }
   }
 
   if $riemann::tools::net_enabled == true {
     user { $riemann::tools::net_user:
       ensure => present,
-      system => true,
+      system => $riemann::tools::system_user,
     }
   }
 


### PR DESCRIPTION
This change adds package support via a `riemann::use_package` flag. Setting this to true with use a package from upstream and not via the tarball method. This will also use init scripts that work with Xenial. There is also puppet 4 support in the config.pp to use the correct puppetlabs path